### PR TITLE
Fixed bug when 'hundred' string returns 0

### DIFF
--- a/text2num.py
+++ b/text2num.py
@@ -82,7 +82,7 @@ def text2num(s):
         x = Small.get(w, None)
         if x is not None:
             g += x
-        elif w == "hundred":
+        elif w == "hundred" and g != 0:
             g *= 100
         else:
             x = Magnitude.get(w, None)


### PR DESCRIPTION
I've noticed if the input string is 'hundred' text2num returns 0 instead of raising of exception. So there is definitely needed additional check